### PR TITLE
Fix ID validation

### DIFF
--- a/development_utilities/gen_unit_test_template.py
+++ b/development_utilities/gen_unit_test_template.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from enum import Enum
+import uuid
 import inspect
 import pprint
 import random
@@ -14,7 +15,7 @@ from typing import (
     Callable,
     Sequence,
 )
-import uuid
+
 
 import pydantic
 
@@ -172,7 +173,7 @@ def dump_test_data_as_constructor_field_for(test_data, field_type: Type) -> str:
         offset: datetime.timedelta = test_data.tzinfo.utcoffset(None)
         value = f"datetime(year={test_data.year}, month={test_data.month}, day={test_data.day}, hour={test_data.hour}, minute={test_data.minute}, second={test_data.second}, tzinfo=offset(offset=timedelta(seconds={offset.total_seconds()})))"
     elif field_type is uuid.UUID:
-        value = f'uuid.UUID("{test_data}")'
+        value = f'"{test_data}"'
     else:
         raise RuntimeError(
             f"Please implement dump test data for field type {field_type}"
@@ -260,7 +261,7 @@ for class_name, class_ in inspect.getmembers(frbc):
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *

--- a/development_utilities/generate_s2_message_type_to_class.py
+++ b/development_utilities/generate_s2_message_type_to_class.py
@@ -5,14 +5,20 @@ all_members = inspect.getmembers(s2python.generated.gen_s2)
 all_members.sort(key=lambda t: t[0])
 
 
-print("""
+print(
+    """
 from s2python.common import *
 from s2python.frbc import *
 
-TYPE_TO_MESSAGE_CLASS = {""")
+TYPE_TO_MESSAGE_CLASS = {"""
+)
 
 for name, member in all_members:
-    if inspect.isclass(member) and hasattr(member, '__fields__') and ('message_type' in member.__fields__):
+    if (
+        inspect.isclass(member)
+        and hasattr(member, "__fields__")
+        and ("message_type" in member.__fields__)
+    ):
         print(f"    '{member.__fields__['message_type'].default}': {name},")
 
 print("}")

--- a/src/s2python/common/handshake.py
+++ b/src/s2python/common/handshake.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import Handshake as GenHandshake
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,5 +9,3 @@ from s2python.validate_values_mixin import (
 class Handshake(GenHandshake, S2Message["Handshake"]):
     class Config(GenHandshake.Config):
         validate_assignment = True
-
-    message_id: uuid.UUID = GenHandshake.__fields__["message_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/common/handshake_response.py
+++ b/src/s2python/common/handshake_response.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import HandshakeResponse as GenHandshakeResponse
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,5 +9,3 @@ from s2python.validate_values_mixin import (
 class HandshakeResponse(GenHandshakeResponse, S2Message["HandshakeResponse"]):
     class Config(GenHandshakeResponse.Config):
         validate_assignment = True
-
-    message_id: uuid.UUID = GenHandshakeResponse.__fields__["message_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/common/instruction_status_update.py
+++ b/src/s2python/common/instruction_status_update.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import (
     InstructionStatusUpdate as GenInstructionStatusUpdate,
 )
@@ -15,8 +13,3 @@ class InstructionStatusUpdate(
 ):
     class Config(GenInstructionStatusUpdate.Config):
         validate_assignment = True
-
-    message_id: uuid.UUID = GenInstructionStatusUpdate.__fields__["message_id"].field_info  # type: ignore[assignment]
-    instruction_id: uuid.UUID = GenInstructionStatusUpdate.__fields__[
-        "instruction_id"
-    ].field_info  # type: ignore[assignment]

--- a/src/s2python/common/power_forecast.py
+++ b/src/s2python/common/power_forecast.py
@@ -1,5 +1,5 @@
 from typing import List
-import uuid
+
 
 from s2python.common.power_forecast_element import PowerForecastElement
 from s2python.generated.gen_s2 import PowerForecast as GenPowerForecast
@@ -14,7 +14,6 @@ class PowerForecast(GenPowerForecast, S2Message["PowerForecast"]):
     class Config(GenPowerForecast.Config):
         validate_assignment = True
 
-    message_id: uuid.UUID = GenPowerForecast.__fields__["message_id"].field_info  # type: ignore[assignment]
     elements: List[PowerForecastElement] = GenPowerForecast.__fields__[
         "elements"
     ].field_info  # type: ignore[assignment]

--- a/src/s2python/common/power_measurement.py
+++ b/src/s2python/common/power_measurement.py
@@ -1,5 +1,5 @@
 from typing import List
-import uuid
+
 
 from s2python.common.power_value import PowerValue
 from s2python.generated.gen_s2 import PowerMeasurement as GenPowerMeasurement
@@ -14,5 +14,4 @@ class PowerMeasurement(GenPowerMeasurement, S2Message["PowerMeasurement"]):
     class Config(GenPowerMeasurement.Config):
         validate_assignment = True
 
-    message_id: uuid.UUID = GenPowerMeasurement.__fields__["message_id"].field_info  # type: ignore[assignment]
     values: List[PowerValue] = GenPowerMeasurement.__fields__["values"].field_info  # type: ignore[assignment]

--- a/src/s2python/common/reception_status.py
+++ b/src/s2python/common/reception_status.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import ReceptionStatus as GenReceptionStatus
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,7 +9,3 @@ from s2python.validate_values_mixin import (
 class ReceptionStatus(GenReceptionStatus, S2Message["ReceptionStatus"]):
     class Config(GenReceptionStatus.Config):
         validate_assignment = True
-
-    subject_message_id: uuid.UUID = GenReceptionStatus.__fields__[
-        "subject_message_id"
-    ].field_info  # type: ignore[assignment]

--- a/src/s2python/common/resource_manager_details.py
+++ b/src/s2python/common/resource_manager_details.py
@@ -1,5 +1,5 @@
 from typing import List
-import uuid
+
 
 from s2python.common.duration import Duration
 from s2python.common.role import Role
@@ -22,6 +22,5 @@ class ResourceManagerDetails(
     instruction_processing_delay: Duration = GenResourceManagerDetails.__fields__[
         "instruction_processing_delay"
     ].field_info  # type: ignore[assignment]
-    message_id: uuid.UUID = GenResourceManagerDetails.__fields__["message_id"].field_info  # type: ignore[assignment]
-    resource_id: uuid.UUID = GenResourceManagerDetails.__fields__["resource_id"].field_info  # type: ignore[assignment]
+
     roles: List[Role] = GenResourceManagerDetails.__fields__["roles"].field_info  # type: ignore[assignment]

--- a/src/s2python/common/revoke_object.py
+++ b/src/s2python/common/revoke_object.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import RevokeObject as GenRevokeObject
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,6 +9,3 @@ from s2python.validate_values_mixin import (
 class RevokeObject(GenRevokeObject, S2Message["RevokeObject"]):
     class Config(GenRevokeObject.Config):
         validate_assignment = True
-
-    message_id: uuid.UUID = GenRevokeObject.__fields__["message_id"].field_info  # type: ignore[assignment]
-    object_id: uuid.UUID = GenRevokeObject.__fields__["object_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/common/select_control_type.py
+++ b/src/s2python/common/select_control_type.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import SelectControlType as GenSelectControlType
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,5 +9,3 @@ from s2python.validate_values_mixin import (
 class SelectControlType(GenSelectControlType, S2Message["SelectControlType"]):
     class Config(GenSelectControlType.Config):
         validate_assignment = True
-
-    message_id: uuid.UUID = GenSelectControlType.__fields__["message_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/common/session_request.py
+++ b/src/s2python/common/session_request.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import SessionRequest as GenSessionRequest
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,5 +9,3 @@ from s2python.validate_values_mixin import (
 class SessionRequest(GenSessionRequest, S2Message["SessionRequest"]):
     class Config(GenSessionRequest.Config):
         validate_assignment = True
-
-    message_id: uuid.UUID = GenSessionRequest.__fields__["message_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/common/timer.py
+++ b/src/s2python/common/timer.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.common.duration import Duration
 from s2python.generated.gen_s2 import Timer as GenTimer
 from s2python.validate_values_mixin import (
@@ -13,5 +11,4 @@ class Timer(GenTimer, S2Message["Timer"]):
     class Config(GenTimer.Config):
         validate_assignment = True
 
-    id: uuid.UUID = GenTimer.__fields__["id"].field_info  # type: ignore[assignment]
     duration: Duration = GenTimer.__fields__["duration"].field_info  # type: ignore[assignment]

--- a/src/s2python/common/transition.py
+++ b/src/s2python/common/transition.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Optional, List
 
 from s2python.common.duration import Duration
@@ -14,13 +13,6 @@ class Transition(GenTransition, S2Message["Transition"]):
     class Config(GenTransition.Config):
         validate_assignment = True
 
-    id: uuid.UUID = GenTransition.__fields__["id"].field_info  # type: ignore[assignment]
-    from_: uuid.UUID = GenTransition.__fields__["from_"].field_info  # type: ignore[assignment]
-    to: uuid.UUID = GenTransition.__fields__["to"].field_info  # type: ignore[assignment]
-    start_timers: List[uuid.UUID] = GenTransition.__fields__["start_timers"].field_info  # type: ignore[assignment]
-    blocking_timers: List[uuid.UUID] = GenTransition.__fields__[
-        "blocking_timers"
-    ].field_info  # type: ignore[assignment]
     transition_duration: Optional[Duration] = GenTransition.__fields__[
         "transition_duration"
     ].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_actuator_description.py
+++ b/src/s2python/frbc/frbc_actuator_description.py
@@ -1,5 +1,3 @@
-import uuid
-
 from typing import List, Any, Dict
 
 from pydantic import root_validator
@@ -24,7 +22,6 @@ class FRBCActuatorDescription(
     class Config(GenFRBCActuatorDescription.Config):
         validate_assignment = True
 
-    id: uuid.UUID = GenFRBCActuatorDescription.__fields__["id"].field_info  # type: ignore[assignment]
     operation_modes: List[FRBCOperationMode] = GenFRBCActuatorDescription.__fields__[
         "operation_modes"
     ].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_actuator_status.py
+++ b/src/s2python/frbc/frbc_actuator_status.py
@@ -1,5 +1,5 @@
 from typing import Optional
-import uuid
+
 
 from s2python.generated.gen_s2 import FRBCActuatorStatus as GenFRBCActuatorStatus
 from s2python.validate_values_mixin import (
@@ -12,12 +12,3 @@ from s2python.validate_values_mixin import (
 class FRBCActuatorStatus(GenFRBCActuatorStatus, S2Message["FRBCActuatorStatus"]):
     class Config(GenFRBCActuatorStatus.Config):
         validate_assignment = True
-
-    active_operation_mode_id: uuid.UUID = GenFRBCActuatorStatus.__fields__[
-        "active_operation_mode_id"
-    ].field_info  # type: ignore[assignment]
-    actuator_id: uuid.UUID = GenFRBCActuatorStatus.__fields__["actuator_id"].field_info  # type: ignore[assignment]
-    message_id: uuid.UUID = GenFRBCActuatorStatus.__fields__["message_id"].field_info  # type: ignore[assignment]
-    previous_operation_mode_id: Optional[uuid.UUID] = GenFRBCActuatorStatus.__fields__[
-        "previous_operation_mode_id"
-    ].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_fill_level_target_profile.py
+++ b/src/s2python/frbc/frbc_fill_level_target_profile.py
@@ -1,5 +1,5 @@
 from typing import List
-import uuid
+
 
 from s2python.frbc.frbc_fill_level_target_profile_element import (
     FRBCFillLevelTargetProfileElement,
@@ -24,7 +24,4 @@ class FRBCFillLevelTargetProfile(
         FRBCFillLevelTargetProfileElement
     ] = GenFRBCFillLevelTargetProfile.__fields__[
         "elements"
-    ].field_info  # type: ignore[assignment]
-    message_id: uuid.UUID = GenFRBCFillLevelTargetProfile.__fields__[
-        "message_id"
     ].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_instruction.py
+++ b/src/s2python/frbc/frbc_instruction.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import FRBCInstruction as GenFRBCInstruction
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,8 +9,3 @@ from s2python.validate_values_mixin import (
 class FRBCInstruction(GenFRBCInstruction, S2Message["FRBCInstruction"]):
     class Config(GenFRBCInstruction.Config):
         validate_assignment = True
-
-    actuator_id: uuid.UUID = GenFRBCInstruction.__fields__["actuator_id"].field_info  # type: ignore[assignment]
-    id: uuid.UUID = GenFRBCInstruction.__fields__["id"].field_info  # type: ignore[assignment]
-    message_id: uuid.UUID = GenFRBCInstruction.__fields__["message_id"].field_info  # type: ignore[assignment]
-    operation_mode: uuid.UUID = GenFRBCInstruction.__fields__["operation_mode"].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_leakage_behaviour.py
+++ b/src/s2python/frbc/frbc_leakage_behaviour.py
@@ -1,5 +1,5 @@
 from typing import List
-import uuid
+
 
 from s2python.frbc.frbc_leakage_behaviour_element import FRBCLeakageBehaviourElement
 from s2python.generated.gen_s2 import FRBCLeakageBehaviour as GenFRBCLeakageBehaviour
@@ -17,4 +17,3 @@ class FRBCLeakageBehaviour(GenFRBCLeakageBehaviour, S2Message["FRBCLeakageBehavi
     elements: List[FRBCLeakageBehaviourElement] = GenFRBCLeakageBehaviour.__fields__[
         "elements"
     ].field_info  # type: ignore[assignment]
-    message_id: uuid.UUID = GenFRBCLeakageBehaviour.__fields__["message_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_operation_mode.py
+++ b/src/s2python/frbc/frbc_operation_mode.py
@@ -1,5 +1,5 @@
 # from itertools import pairwise
-import uuid
+
 from typing import List, Dict, Any
 
 from pydantic import root_validator
@@ -19,7 +19,6 @@ class FRBCOperationMode(GenFRBCOperationMode, S2Message["FRBCOperationMode"]):
     class Config(GenFRBCOperationMode.Config):
         validate_assignment = True
 
-    id: uuid.UUID = GenFRBCOperationMode.__fields__["id"].field_info  # type: ignore[assignment]
     elements: List[FRBCOperationModeElement] = GenFRBCOperationMode.__fields__[
         "elements"
     ].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_storage_status.py
+++ b/src/s2python/frbc/frbc_storage_status.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import FRBCStorageStatus as GenFRBCStorageStatus
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,5 +9,3 @@ from s2python.validate_values_mixin import (
 class FRBCStorageStatus(GenFRBCStorageStatus, S2Message["FRBCStorageStatus"]):
     class Config(GenFRBCStorageStatus.Config):
         validate_assignment = True
-
-    message_id: uuid.UUID = GenFRBCStorageStatus.__fields__["message_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_system_description.py
+++ b/src/s2python/frbc/frbc_system_description.py
@@ -1,5 +1,5 @@
 from typing import List
-import uuid
+
 
 from s2python.generated.gen_s2 import FRBCSystemDescription as GenFRBCSystemDescription
 from s2python.validate_values_mixin import (
@@ -20,7 +20,7 @@ class FRBCSystemDescription(
     actuators: List[FRBCActuatorDescription] = GenFRBCSystemDescription.__fields__[
         "actuators"
     ].field_info  # type: ignore[assignment]
-    message_id: uuid.UUID = GenFRBCSystemDescription.__fields__["message_id"].field_info  # type: ignore[assignment]
+
     storage: FRBCStorageDescription = GenFRBCSystemDescription.__fields__[
         "storage"
     ].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_timer_status.py
+++ b/src/s2python/frbc/frbc_timer_status.py
@@ -1,5 +1,3 @@
-import uuid
-
 from s2python.generated.gen_s2 import FRBCTimerStatus as GenFRBCTimerStatus
 from s2python.validate_values_mixin import (
     catch_and_convert_exceptions,
@@ -11,7 +9,3 @@ from s2python.validate_values_mixin import (
 class FRBCTimerStatus(GenFRBCTimerStatus, S2Message["FRBCTimerStatus"]):
     class Config(GenFRBCTimerStatus.Config):
         validate_assignment = True
-
-    actuator_id: uuid.UUID = GenFRBCTimerStatus.__fields__["actuator_id"].field_info  # type: ignore[assignment]
-    message_id: uuid.UUID = GenFRBCTimerStatus.__fields__["message_id"].field_info  # type: ignore[assignment]
-    timer_id: uuid.UUID = GenFRBCTimerStatus.__fields__["timer_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/frbc/frbc_usage_forecast.py
+++ b/src/s2python/frbc/frbc_usage_forecast.py
@@ -1,5 +1,5 @@
 from typing import List
-import uuid
+
 
 from s2python.generated.gen_s2 import FRBCUsageForecast as GenFRBCUsageForecast
 from s2python.validate_values_mixin import (
@@ -17,4 +17,3 @@ class FRBCUsageForecast(GenFRBCUsageForecast, S2Message["FRBCUsageForecast"]):
     elements: List[FRBCUsageForecastElement] = GenFRBCUsageForecast.__fields__[
         "elements"
     ].field_info  # type: ignore[assignment]
-    message_id: uuid.UUID = GenFRBCUsageForecast.__fields__["message_id"].field_info  # type: ignore[assignment]

--- a/src/s2python/generated/gen_s2.py
+++ b/src/s2python/generated/gen_s2.py
@@ -190,10 +190,7 @@ class FRBCUsageForecastElement(BaseModel):
     )
 
 
-class ID(BaseModel):
-    __root__: constr(regex=r"[a-zA-Z0-9\-_:]{2,64}") = Field(
-        ..., description="An identifier expressed as a UUID"
-    )
+ID = constr(regex=r"[a-zA-Z0-9\-_:]{2,64}")
 
 
 class InstructionStatus(Enum):

--- a/tests/unit/common/handshake_response_test.py
+++ b/tests/unit/common/handshake_response_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from unittest import TestCase
 
 from s2python.common import HandshakeResponse
@@ -19,7 +19,7 @@ class HandshakeResponseTest(TestCase):
         # Assert
         self.assertEqual(
             handshake_response.message_id,
-            uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
+            "2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
         )
         self.assertEqual(handshake_response.message_type, "HandshakeResponse")
         self.assertEqual(handshake_response.selected_protocol_version, "v1")
@@ -27,7 +27,7 @@ class HandshakeResponseTest(TestCase):
     def test__to_json__happy_path(self):
         # Arrange
         handshake_response = HandshakeResponse(
-            message_id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
+            message_id="2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
             selected_protocol_version="v1",
         )
 

--- a/tests/unit/common/handshake_test.py
+++ b/tests/unit/common/handshake_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from unittest import TestCase
 
 from s2python.common import Handshake, EnergyManagementRole
@@ -17,14 +17,14 @@ class HandshakeTest(TestCase):
         handshake = Handshake.from_json(json_str)
 
         # Assert
-        self.assertEqual(handshake.message_id, uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"))
+        self.assertEqual(handshake.message_id, "2bdec96b-be3b-4ba9-afa0-c4a0632cced3")
         self.assertEqual(handshake.role, EnergyManagementRole.RM)
         self.assertEqual(handshake.supported_protocol_versions, ["v1", "v2"])
 
     def test__to_json__happy_path(self):
         # Arrange
         handshake = Handshake(
-            message_id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
+            message_id="2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
             role=EnergyManagementRole.CEM,
             supported_protocol_versions=["v3"],
         )

--- a/tests/unit/common/instruction_status_update_test.py
+++ b/tests/unit/common/instruction_status_update_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone as offset, timedelta
 import json
-import uuid
+
 from unittest import TestCase
 
 from pytz import timezone
@@ -24,13 +24,15 @@ class InstructionStatusUpdateTest(TestCase):
         # Assert
         self.assertEqual(
             instruction_status_update.message_id,
-            uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
+            "2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
         )
         self.assertEqual(
             instruction_status_update.instruction_id,
-            uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced4"),
+            "2bdec96b-be3b-4ba9-afa0-c4a0632cced4",
         )
-        self.assertEqual(instruction_status_update.status_type, InstructionStatus.SUCCEEDED)
+        self.assertEqual(
+            instruction_status_update.status_type, InstructionStatus.SUCCEEDED
+        )
         self.assertEqual(
             instruction_status_update.timestamp,
             datetime(2023, 8, 2, 12, 48, 42, tzinfo=offset(timedelta(hours=1))),
@@ -39,10 +41,12 @@ class InstructionStatusUpdateTest(TestCase):
     def test__to_json__happy_path(self):
         # Arrange
         instruction_status_update = InstructionStatusUpdate(
-            message_id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
-            instruction_id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced4"),
+            message_id="2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
+            instruction_id="2bdec96b-be3b-4ba9-afa0-c4a0632cced4",
             status_type=InstructionStatus.SUCCEEDED,
-            timestamp=timezone("Europe/Amsterdam").localize(datetime(2023, 8, 2, 12, 48, 42)),
+            timestamp=timezone("Europe/Amsterdam").localize(
+                datetime(2023, 8, 2, 12, 48, 42)
+            ),
         )
 
         # Act

--- a/tests/unit/common/power_forecast_element_test.py
+++ b/tests/unit/common/power_forecast_element_test.py
@@ -54,6 +54,8 @@ class PowerForecastElementTest(TestCase):
         # Assert
         expected_json = {
             "duration": 4000,
-            "power_values": [{"commodity_quantity": "NATURAL_GAS.FLOW_RATE", "value_expected": 500.2}],
+            "power_values": [
+                {"commodity_quantity": "NATURAL_GAS.FLOW_RATE", "value_expected": 500.2}
+            ],
         }
         self.assertEqual(json.loads(json_str), expected_json)

--- a/tests/unit/common/power_forecast_test.py
+++ b/tests/unit/common/power_forecast_test.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
@@ -37,7 +36,7 @@ class PowerForecastTest(TestCase):
         )
         self.assertEqual(power_forecast.elements, [power_forecast_element])
         self.assertEqual(
-            power_forecast.message_id, uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced9")
+            power_forecast.message_id, "2bdec96b-be3b-4ba9-afa0-c4a0632cced9"
         )
         self.assertEqual(
             power_forecast.start_time,
@@ -57,7 +56,7 @@ class PowerForecastTest(TestCase):
         )
         power_forecast = PowerForecast(
             elements=[power_forecast_element],
-            message_id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced9"),
+            message_id="2bdec96b-be3b-4ba9-afa0-c4a0632cced9",
             start_time=datetime(
                 2023, 8, 2, 12, 48, 42, tzinfo=offset(timedelta(hours=2))
             ),

--- a/tests/unit/common/power_measurement_test.py
+++ b/tests/unit/common/power_measurement_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone as offset, timedelta
 import json
-import uuid
+
 from unittest import TestCase
 
 from s2python.common import PowerMeasurement, PowerValue, CommodityQuantity
@@ -22,7 +22,7 @@ class PowerMeasurementTest(TestCase):
         # Assert
         self.assertEqual(
             power_measurement.message_id,
-            uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced8"),
+            "2bdec96b-be3b-4ba9-afa0-c4a0632cced8",
         )
         self.assertEqual(
             power_measurement.measurement_timestamp,
@@ -30,15 +30,25 @@ class PowerMeasurementTest(TestCase):
         )
         self.assertEqual(
             power_measurement.values,
-            [PowerValue(commodity_quantity=CommodityQuantity.OIL_FLOW_RATE, value=42.42)],
+            [
+                PowerValue(
+                    commodity_quantity=CommodityQuantity.OIL_FLOW_RATE, value=42.42
+                )
+            ],
         )
 
     def test__to_json__happy_path(self):
         # Arrange
         power_measurement = PowerMeasurement(
-            values=[PowerValue(commodity_quantity=CommodityQuantity.OIL_FLOW_RATE, value=42.42)],
-            message_id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced8"),
-            measurement_timestamp=datetime(2023, 8, 3, 12, 48, 42, tzinfo=offset(timedelta(hours=1))),
+            values=[
+                PowerValue(
+                    commodity_quantity=CommodityQuantity.OIL_FLOW_RATE, value=42.42
+                )
+            ],
+            message_id="2bdec96b-be3b-4ba9-afa0-c4a0632cced8",
+            measurement_timestamp=datetime(
+                2023, 8, 3, 12, 48, 42, tzinfo=offset(timedelta(hours=1))
+            ),
         )
 
         # Act

--- a/tests/unit/common/reception_status_test.py
+++ b/tests/unit/common/reception_status_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from unittest import TestCase
 
 from s2python.common import ReceptionStatus, ReceptionStatusValues
@@ -23,7 +23,7 @@ class ReceptionStatusTest(TestCase):
         self.assertEqual(reception_status.status, ReceptionStatusValues.TEMPORARY_ERROR)
         self.assertEqual(
             reception_status.subject_message_id,
-            uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced5"),
+            "2bdec96b-be3b-4ba9-afa0-c4a0632cced5",
         )
 
     def test__to_json__happy_path(self):
@@ -32,7 +32,7 @@ class ReceptionStatusTest(TestCase):
             diagnostic_label="Dagobert Duck is king!",
             message_type="ReceptionStatus",
             status=ReceptionStatusValues.OK,
-            subject_message_id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced5"),
+            subject_message_id="2bdec96b-be3b-4ba9-afa0-c4a0632cced5",
         )
 
         # Act

--- a/tests/unit/common/resource_manager_details_test.py
+++ b/tests/unit/common/resource_manager_details_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from datetime import timedelta
 from unittest import TestCase
 
@@ -59,7 +59,7 @@ class ResourceManagerDetailsTest(TestCase):
         self.assertEqual(resource_manager_details.manufacturer, "Dagobert inc.")
         self.assertEqual(
             resource_manager_details.message_id,
-            uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced5"),
+            "3bdec96b-be3b-4ba9-afa0-c4a0632cced5",
         )
         self.assertEqual(resource_manager_details.model, "Safe")
         self.assertEqual(resource_manager_details.name, "Dagobert's safe")
@@ -73,7 +73,7 @@ class ResourceManagerDetailsTest(TestCase):
         )
         self.assertEqual(
             resource_manager_details.resource_id,
-            uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced6"),
+            "3bdec96b-be3b-4ba9-afa0-c4a0632cced6",
         )
         self.assertEqual(
             resource_manager_details.roles,
@@ -98,7 +98,7 @@ class ResourceManagerDetailsTest(TestCase):
                 timedelta(milliseconds=342)
             ),
             manufacturer="Dagobert inc.",
-            message_id=uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced5"),
+            message_id="3bdec96b-be3b-4ba9-afa0-c4a0632cced5",
             model="Safe",
             name="Dagobert's safe",
             provides_forecast=True,
@@ -106,7 +106,7 @@ class ResourceManagerDetailsTest(TestCase):
                 CommodityQuantity.HEAT_THERMAL_POWER,
                 CommodityQuantity.ELECTRIC_POWER_3_PHASE_SYMMETRIC,
             ],
-            resource_id=uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced6"),
+            resource_id="3bdec96b-be3b-4ba9-afa0-c4a0632cced6",
             roles=[
                 Role(commodity=Commodity.HEAT, role=RoleType.ENERGY_PRODUCER),
                 Role(commodity=Commodity.ELECTRICITY, role=RoleType.ENERGY_CONSUMER),

--- a/tests/unit/common/revoke_object_test.py
+++ b/tests/unit/common/revoke_object_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from unittest import TestCase
 
 from s2python.common import RevokeObject, RevokableObjects
@@ -21,18 +21,18 @@ class RevokeObjectTest(TestCase):
 
         # Assert
         self.assertEqual(
-            revoke_object.message_id, uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced5")
+            revoke_object.message_id, "3bdec96b-be3b-4ba9-afa0-c4a0632cced5"
         )
         self.assertEqual(
-            revoke_object.object_id, uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced6")
+            revoke_object.object_id, "3bdec96b-be3b-4ba9-afa0-c4a0632cced6"
         )
         self.assertEqual(revoke_object.object_type, RevokableObjects.FRBC_Instruction)
 
     def test__to_json__happy_path(self):
         # Arrange
         revoke_object = RevokeObject(
-            message_id=uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced5"),
-            object_id=uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced6"),
+            message_id="3bdec96b-be3b-4ba9-afa0-c4a0632cced5",
+            object_id="3bdec96b-be3b-4ba9-afa0-c4a0632cced6",
             object_type=RevokableObjects.FRBC_Instruction,
         )
 

--- a/tests/unit/common/select_control_type_test.py
+++ b/tests/unit/common/select_control_type_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from unittest import TestCase
 
 from s2python.common import SelectControlType, ControlType
@@ -20,7 +20,7 @@ class SelectControlTypeTest(TestCase):
         # Assert
         self.assertEqual(
             select_control_type.message_id,
-            uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced5"),
+            "3bdec96b-be3b-4ba9-afa0-c4a0632cced5",
         )
         self.assertEqual(
             select_control_type.control_type, ControlType.OPERATION_MODE_BASED_CONTROL

--- a/tests/unit/common/session_request_test.py
+++ b/tests/unit/common/session_request_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from unittest import TestCase
 
 from s2python.common import SessionRequest, SessionRequestType
@@ -20,14 +20,14 @@ class SessionRequestTest(TestCase):
         # Assert
         self.assertEqual(
             session_request.message_id,
-            uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632cced5"),
+            "3bdec96b-be3b-4ba9-afa0-c4a0632cced5",
         )
         self.assertEqual(session_request.request, SessionRequestType.TERMINATE)
 
     def test__to_json__happy_path(self):
         # Arrange
         session_request = SessionRequest(
-            message_id=uuid.UUID("3bdec96e-be3b-4ba9-afa0-c4a0632cced5"),
+            message_id="3bdec96e-be3b-4ba9-afa0-c4a0632cced5",
             request=SessionRequestType.RECONNECT,
         )
 

--- a/tests/unit/common/timer_test.py
+++ b/tests/unit/common/timer_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from datetime import timedelta
 from unittest import TestCase
 
@@ -17,7 +17,7 @@ class TimerTest(TestCase):
         timer = Timer.from_json(json_str)
 
         # Assert
-        expected_id = uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632ccedf")
+        expected_id = "2bdec96b-be3b-4ba9-afa0-c4a0632ccedf"
         expected_duration = timedelta(seconds=5)
         expected_diagnostic_label = "some_label"
         self.assertEqual(timer.id, expected_id)
@@ -27,12 +27,12 @@ class TimerTest(TestCase):
     def test_optional_parameters(self):
         # Arrange / Act
         timer = Timer(
-            id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632ccedf"),
+            id="2bdec96b-be3b-4ba9-afa0-c4a0632ccedf",
             duration=Duration.from_timedelta(timedelta(seconds=5)),
         )
 
         # Assert
-        expected_id = uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632ccedf")
+        expected_id = "2bdec96b-be3b-4ba9-afa0-c4a0632ccedf"
         expected_duration = timedelta(seconds=5)
 
         self.assertIsNone(timer.diagnostic_label)
@@ -50,7 +50,7 @@ class TimerTest(TestCase):
     def test__to_json__happy_path(self):
         # Arrange
         timer = Timer(
-            id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632ccedf"),
+            id="2bdec96b-be3b-4ba9-afa0-c4a0632ccedf",
             duration=Duration.from_timedelta(timedelta(seconds=5)),
             diagnostic_label="some_label",
         )
@@ -69,7 +69,7 @@ class TimerTest(TestCase):
     def test__assignment__overriden_duration_field(self):
         # Arrange
         timer = Timer(
-            id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632ccedf"),
+            id="2bdec96b-be3b-4ba9-afa0-c4a0632ccedf",
             duration=Duration.from_timedelta(timedelta(seconds=5)),
             diagnostic_label="some_label",
         )
@@ -78,7 +78,7 @@ class TimerTest(TestCase):
         timer.duration = Duration.from_timedelta(timedelta(seconds=4))
 
         # Assert
-        expected_id = uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632ccedf")
+        expected_id = "2bdec96b-be3b-4ba9-afa0-c4a0632ccedf"
         expected_duration = timedelta(seconds=4)
         expected_diagnostic_label = "some_label"
         self.assertEqual(timer.id, expected_id)

--- a/tests/unit/common/transition_test.py
+++ b/tests/unit/common/transition_test.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import timedelta
 import json
 from unittest import TestCase
@@ -25,25 +24,19 @@ class TransitionTest(TestCase):
         transition: Transition = Transition.from_json(json_str)
 
         # Assert
-        self.assertEqual(
-            transition.id, uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3")
-        )
-        self.assertEqual(
-            transition.from_, uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced2")
-        )
-        self.assertEqual(
-            transition.to, uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced1")
-        )
+        self.assertEqual(transition.id, "2bdec96b-be3b-4ba9-afa0-c4a0632cced3")
+        self.assertEqual(transition.from_, "2bdec96b-be3b-4ba9-afa0-c4a0632cced2")
+        self.assertEqual(transition.to, "2bdec96b-be3b-4ba9-afa0-c4a0632cced1")
         self.assertEqual(
             transition.start_timers,
             [
-                uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced4"),
-                uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced5"),
+                "2bdec96b-be3b-4ba9-afa0-c4a0632cced4",
+                "2bdec96b-be3b-4ba9-afa0-c4a0632cced5",
             ],
         )
         self.assertEqual(
             transition.blocking_timers,
-            [uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced4")],
+            ["2bdec96b-be3b-4ba9-afa0-c4a0632cced4"],
         )
         self.assertEqual(transition.transition_costs, 4.3)
         assert transition.transition_duration is not None
@@ -67,15 +60,9 @@ class TransitionTest(TestCase):
         transition: Transition = Transition.from_json(json_str)
 
         # Assert
-        self.assertEqual(
-            transition.id, uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3")
-        )
-        self.assertEqual(
-            transition.from_, uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced2")
-        )
-        self.assertEqual(
-            transition.to, uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced1")
-        )
+        self.assertEqual(transition.id, "2bdec96b-be3b-4ba9-afa0-c4a0632cced3")
+        self.assertEqual(transition.from_, "2bdec96b-be3b-4ba9-afa0-c4a0632cced2")
+        self.assertEqual(transition.to, "2bdec96b-be3b-4ba9-afa0-c4a0632cced1")
         self.assertEqual(transition.start_timers, [])
         self.assertEqual(transition.blocking_timers, [])
         self.assertEqual(transition.transition_costs, None)
@@ -115,9 +102,9 @@ class TransitionTest(TestCase):
         #  assign values during init. See: https://github.com/flexiblepower/s2-ws-json-python/issues/10
         transition = Transition(
             **{
-                "id": uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
-                "from": uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced2"),
-                "to": uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced1"),
+                "id": "2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
+                "from": "2bdec96b-be3b-4ba9-afa0-c4a0632cced2",
+                "to": "2bdec96b-be3b-4ba9-afa0-c4a0632cced1",
                 "start_timers": [],
                 "blocking_timers": [],
                 "transition_duration": Duration.from_timedelta(
@@ -146,9 +133,9 @@ class TransitionTest(TestCase):
         # Arrange/ Act / Assert
         with self.assertRaises(S2ValidationError):
             Transition(
-                id=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
-                from_=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced2"),
-                to=uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced1"),
+                id="2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
+                from_="2bdec96b-be3b-4ba9-afa0-c4a0632cced2",
+                to="2bdec96b-be3b-4ba9-afa0-c4a0632cced1",
                 start_timers=[],
                 blocking_timers=[],
                 transition_duration=Duration(__root__=-5000),

--- a/tests/unit/frbc/frbc_actuator_description_test.py
+++ b/tests/unit/frbc/frbc_actuator_description_test.py
@@ -1,5 +1,5 @@
 import json
-import uuid
+
 from datetime import timedelta
 from unittest import TestCase
 
@@ -58,7 +58,7 @@ class FRBCActuatorDescriptionTest(TestCase):
 
         # Assert
         expected_timer = Timer(
-            id=uuid.UUID("3bdec10b-be3b-4ba9-afa0-c4a0632ffed6"),
+            id="3bdec10b-be3b-4ba9-afa0-c4a0632ffed6",
             diagnostic_label="timer1",
             duration=Duration.from_timedelta(timedelta(seconds=2.3)),
         )
@@ -68,11 +68,11 @@ class FRBCActuatorDescriptionTest(TestCase):
         #  assign values during init. See: https://github.com/flexiblepower/s2-ws-json-python/issues/10
         expected_transition = Transition(
             **{
-                "id": uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
-                "from": uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632ffed5"),
-                "to": uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632ffed5"),
-                "start_timers": [uuid.UUID("3bdec10b-be3b-4ba9-afa0-c4a0632ffed6")],
-                "blocking_timers": [uuid.UUID("3bdec10b-be3b-4ba9-afa0-c4a0632ffed6")],
+                "id": "2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
+                "from": "3bdec96b-be3b-4ba9-afa0-c4a0632ffed5",
+                "to": "3bdec96b-be3b-4ba9-afa0-c4a0632ffed5",
+                "start_timers": ["3bdec10b-be3b-4ba9-afa0-c4a0632ffed6"],
+                "blocking_timers": ["3bdec10b-be3b-4ba9-afa0-c4a0632ffed6"],
                 "transition_costs": 4.3,
                 "transition_duration": Duration.from_milliseconds(1500),
                 "abnormal_condition_only": False,
@@ -98,7 +98,7 @@ class FRBCActuatorDescriptionTest(TestCase):
         expected_operation_mode = FRBCOperationMode(
             abnormal_condition_only=False,
             diagnostic_label="om1",
-            id=uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632ffed5"),
+            id="3bdec96b-be3b-4ba9-afa0-c4a0632ffed5",
             elements=[expected_operation_mode_element],
         )
 
@@ -107,7 +107,7 @@ class FRBCActuatorDescriptionTest(TestCase):
         )
         self.assertEqual(
             frbc_actuator_description.id,
-            uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632dded5"),
+            "3bdec96b-be3b-4ba9-afa0-c4a0632dded5",
         )
         self.assertEqual(
             frbc_actuator_description.supported_commodities,
@@ -122,7 +122,7 @@ class FRBCActuatorDescriptionTest(TestCase):
     def test__to_json__happy_path(self):
         # Arrange
         timer = Timer(
-            id=uuid.UUID("3bdec10b-be3b-4ba9-afa0-c4a0632ffed6"),
+            id="3bdec10b-be3b-4ba9-afa0-c4a0632ffed6",
             diagnostic_label="timer1",
             duration=Duration.from_timedelta(timedelta(seconds=2.3)),
         )
@@ -132,11 +132,11 @@ class FRBCActuatorDescriptionTest(TestCase):
         #  assign values during init. See: https://github.com/flexiblepower/s2-ws-json-python/issues/10
         transition = Transition(
             **{
-                "id": uuid.UUID("2bdec96b-be3b-4ba9-afa0-c4a0632cced3"),
-                "from": uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632ffed5"),
-                "to": uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632ffed5"),
-                "start_timers": [uuid.UUID("3bdec10b-be3b-4ba9-afa0-c4a0632ffed6")],
-                "blocking_timers": [uuid.UUID("3bdec10b-be3b-4ba9-afa0-c4a0632ffed6")],
+                "id": "2bdec96b-be3b-4ba9-afa0-c4a0632cced3",
+                "from": "3bdec96b-be3b-4ba9-afa0-c4a0632ffed5",
+                "to": "3bdec96b-be3b-4ba9-afa0-c4a0632ffed5",
+                "start_timers": ["3bdec10b-be3b-4ba9-afa0-c4a0632ffed6"],
+                "blocking_timers": ["3bdec10b-be3b-4ba9-afa0-c4a0632ffed6"],
                 "transition_costs": 4.3,
                 "transition_duration": Duration.from_milliseconds(1500),
                 "abnormal_condition_only": False,
@@ -162,13 +162,13 @@ class FRBCActuatorDescriptionTest(TestCase):
         operation_mode = FRBCOperationMode(
             abnormal_condition_only=False,
             diagnostic_label="om1",
-            id=uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632ffed5"),
+            id="3bdec96b-be3b-4ba9-afa0-c4a0632ffed5",
             elements=[operation_mode_element],
         )
 
         frbc_actuator_description = FRBCActuatorDescription(
             diagnostic_label="some name of actuator",
-            id=uuid.UUID("3bdec96b-be3b-4ba9-afa0-c4a0632dded5"),
+            id="3bdec96b-be3b-4ba9-afa0-c4a0632dded5",
             supported_commodities=[Commodity.HEAT, Commodity.ELECTRICITY],
             operation_modes=[operation_mode],
             timers=[timer],

--- a/tests/unit/frbc/frbc_actuator_status_test.py
+++ b/tests/unit/frbc/frbc_actuator_status_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -28,21 +28,21 @@ class FRBCActuatorStatusTest(TestCase):
         # Assert
         self.assertEqual(
             frbc_actuator_status.active_operation_mode_id,
-            uuid.UUID("395dcbc5-5c7f-415e-8727-e48fc53761bc"),
+            "395dcbc5-5c7f-415e-8727-e48fc53761bc",
         )
         self.assertEqual(
             frbc_actuator_status.actuator_id,
-            uuid.UUID("1cee425e-861b-417a-8208-bb6d53aafb00"),
+            "1cee425e-861b-417a-8208-bb6d53aafb00",
         )
         self.assertEqual(
             frbc_actuator_status.message_id,
-            uuid.UUID("07f3d559-63c5-4369-a9e0-deed4195f651"),
+            "07f3d559-63c5-4369-a9e0-deed4195f651",
         )
         self.assertEqual(frbc_actuator_status.message_type, "FRBC.ActuatorStatus")
         self.assertEqual(frbc_actuator_status.operation_mode_factor, 6919.960475850124)
         self.assertEqual(
             frbc_actuator_status.previous_operation_mode_id,
-            uuid.UUID("2ed8f7de-cbaa-4cab-9d25-6792317aa284"),
+            "2ed8f7de-cbaa-4cab-9d25-6792317aa284",
         )
         self.assertEqual(
             frbc_actuator_status.transition_timestamp,
@@ -60,14 +60,12 @@ class FRBCActuatorStatusTest(TestCase):
     def test__to_json__happy_path_full(self):
         # Arrange
         frbc_actuator_status = FRBCActuatorStatus(
-            active_operation_mode_id=uuid.UUID("395dcbc5-5c7f-415e-8727-e48fc53761bc"),
-            actuator_id=uuid.UUID("1cee425e-861b-417a-8208-bb6d53aafb00"),
-            message_id=uuid.UUID("07f3d559-63c5-4369-a9e0-deed4195f651"),
+            active_operation_mode_id="395dcbc5-5c7f-415e-8727-e48fc53761bc",
+            actuator_id="1cee425e-861b-417a-8208-bb6d53aafb00",
+            message_id="07f3d559-63c5-4369-a9e0-deed4195f651",
             message_type="FRBC.ActuatorStatus",
             operation_mode_factor=6919.960475850124,
-            previous_operation_mode_id=uuid.UUID(
-                "2ed8f7de-cbaa-4cab-9d25-6792317aa284"
-            ),
+            previous_operation_mode_id="2ed8f7de-cbaa-4cab-9d25-6792317aa284",
             transition_timestamp=datetime(
                 year=2020,
                 month=1,

--- a/tests/unit/frbc/frbc_fill_level_target_profile_element_test.py
+++ b/tests/unit/frbc/frbc_fill_level_target_profile_element_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *

--- a/tests/unit/frbc/frbc_fill_level_target_profile_test.py
+++ b/tests/unit/frbc/frbc_fill_level_target_profile_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -45,7 +45,7 @@ class FRBCFillLevelTargetProfileTest(TestCase):
         )
         self.assertEqual(
             frbc_fill_level_target_profile.message_id,
-            uuid.UUID("04a6c8af-ca8d-420c-9c11-e96a70fe82b1"),
+            "04a6c8af-ca8d-420c-9c11-e96a70fe82b1",
         )
         self.assertEqual(
             frbc_fill_level_target_profile.message_type, "FRBC.FillLevelTargetProfile"
@@ -75,7 +75,7 @@ class FRBCFillLevelTargetProfileTest(TestCase):
                     ),
                 )
             ],
-            message_id=uuid.UUID("04a6c8af-ca8d-420c-9c11-e96a70fe82b1"),
+            message_id="04a6c8af-ca8d-420c-9c11-e96a70fe82b1",
             message_type="FRBC.FillLevelTargetProfile",
             start_time=datetime(
                 year=2021,

--- a/tests/unit/frbc/frbc_instruction_test.py
+++ b/tests/unit/frbc/frbc_instruction_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -30,7 +30,7 @@ class FRBCInstructionTest(TestCase):
         self.assertEqual(frbc_instruction.abnormal_condition, True)
         self.assertEqual(
             frbc_instruction.actuator_id,
-            uuid.UUID("db7855dd-05c4-4ba8-81e2-d10001c5bc3f"),
+            "db7855dd-05c4-4ba8-81e2-d10001c5bc3f",
         )
         self.assertEqual(
             frbc_instruction.execution_time,
@@ -44,17 +44,15 @@ class FRBCInstructionTest(TestCase):
                 tzinfo=offset(offset=timedelta(seconds=3600.0)),
             ),
         )
-        self.assertEqual(
-            frbc_instruction.id, uuid.UUID("9ffd68cd-b0e2-44a6-aded-4dce6c18247e")
-        )
+        self.assertEqual(frbc_instruction.id, "9ffd68cd-b0e2-44a6-aded-4dce6c18247e")
         self.assertEqual(
             frbc_instruction.message_id,
-            uuid.UUID("bcb3e1da-e797-4951-86be-5e5d9136c63f"),
+            "bcb3e1da-e797-4951-86be-5e5d9136c63f",
         )
         self.assertEqual(frbc_instruction.message_type, "FRBC.Instruction")
         self.assertEqual(
             frbc_instruction.operation_mode,
-            uuid.UUID("e7bf29a7-4ebc-49c1-a1fb-20725f450c91"),
+            "e7bf29a7-4ebc-49c1-a1fb-20725f450c91",
         )
         self.assertEqual(frbc_instruction.operation_mode_factor, 2303.58902271682)
 
@@ -62,7 +60,7 @@ class FRBCInstructionTest(TestCase):
         # Arrange
         frbc_instruction = FRBCInstruction(
             abnormal_condition=True,
-            actuator_id=uuid.UUID("db7855dd-05c4-4ba8-81e2-d10001c5bc3f"),
+            actuator_id="db7855dd-05c4-4ba8-81e2-d10001c5bc3f",
             execution_time=datetime(
                 year=2023,
                 month=4,
@@ -72,10 +70,10 @@ class FRBCInstructionTest(TestCase):
                 second=33,
                 tzinfo=offset(offset=timedelta(seconds=3600.0)),
             ),
-            id=uuid.UUID("9ffd68cd-b0e2-44a6-aded-4dce6c18247e"),
-            message_id=uuid.UUID("bcb3e1da-e797-4951-86be-5e5d9136c63f"),
+            id="9ffd68cd-b0e2-44a6-aded-4dce6c18247e",
+            message_id="bcb3e1da-e797-4951-86be-5e5d9136c63f",
             message_type="FRBC.Instruction",
-            operation_mode=uuid.UUID("e7bf29a7-4ebc-49c1-a1fb-20725f450c91"),
+            operation_mode="e7bf29a7-4ebc-49c1-a1fb-20725f450c91",
             operation_mode_factor=2303.58902271682,
         )
 

--- a/tests/unit/frbc/frbc_leakage_behaviour_element_test.py
+++ b/tests/unit/frbc/frbc_leakage_behaviour_element_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *

--- a/tests/unit/frbc/frbc_leakage_behaviour_test.py
+++ b/tests/unit/frbc/frbc_leakage_behaviour_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -45,7 +45,7 @@ class FRBCLeakageBehaviourTest(TestCase):
         )
         self.assertEqual(
             frbc_leakage_behaviour.message_id,
-            uuid.UUID("b3e9604a-1127-4ecc-9f9e-336047fde285"),
+            "b3e9604a-1127-4ecc-9f9e-336047fde285",
         )
         self.assertEqual(frbc_leakage_behaviour.message_type, "FRBC.LeakageBehaviour")
         self.assertEqual(
@@ -73,7 +73,7 @@ class FRBCLeakageBehaviourTest(TestCase):
                     leakage_rate=1225.9695121338086,
                 )
             ],
-            message_id=uuid.UUID("b3e9604a-1127-4ecc-9f9e-336047fde285"),
+            message_id="b3e9604a-1127-4ecc-9f9e-336047fde285",
             message_type="FRBC.LeakageBehaviour",
             valid_from=datetime(
                 year=2022,

--- a/tests/unit/frbc/frbc_operation_mode_element_test.py
+++ b/tests/unit/frbc/frbc_operation_mode_element_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import NumberRange, PowerRange
 from s2python.frbc.frbc_operation_mode_element import FRBCOperationModeElement

--- a/tests/unit/frbc/frbc_operation_mode_test.py
+++ b/tests/unit/frbc/frbc_operation_mode_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -71,9 +71,7 @@ class FRBCOperationModeTest(TestCase):
                 )
             ],
         )
-        self.assertEqual(
-            frbc_operation_mode.id, uuid.UUID("b1255236-475c-4dc7-a728-afb620a99ec8")
-        )
+        self.assertEqual(frbc_operation_mode.id, "b1255236-475c-4dc7-a728-afb620a99ec8")
 
     def test__to_json__happy_path_full(self):
         # Arrange
@@ -101,7 +99,7 @@ class FRBCOperationModeTest(TestCase):
                     ),
                 )
             ],
-            id=uuid.UUID("b1255236-475c-4dc7-a728-afb620a99ec8"),
+            id="b1255236-475c-4dc7-a728-afb620a99ec8",
         )
 
         # Act

--- a/tests/unit/frbc/frbc_storage_description_test.py
+++ b/tests/unit/frbc/frbc_storage_description_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *

--- a/tests/unit/frbc/frbc_storage_status_test.py
+++ b/tests/unit/frbc/frbc_storage_status_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -24,7 +24,7 @@ class FRBCStorageStatusTest(TestCase):
         # Assert
         self.assertEqual(
             frbc_storage_status.message_id,
-            uuid.UUID("6bad8186-9ebf-4647-ac45-1c6856511a2f"),
+            "6bad8186-9ebf-4647-ac45-1c6856511a2f",
         )
         self.assertEqual(frbc_storage_status.message_type, "FRBC.StorageStatus")
         self.assertEqual(frbc_storage_status.present_fill_level, 2443.939298819414)
@@ -32,7 +32,7 @@ class FRBCStorageStatusTest(TestCase):
     def test__to_json__happy_path_full(self):
         # Arrange
         frbc_storage_status = FRBCStorageStatus(
-            message_id=uuid.UUID("6bad8186-9ebf-4647-ac45-1c6856511a2f"),
+            message_id="6bad8186-9ebf-4647-ac45-1c6856511a2f",
             message_type="FRBC.StorageStatus",
             present_fill_level=2443.939298819414,
         )

--- a/tests/unit/frbc/frbc_system_description_test.py
+++ b/tests/unit/frbc/frbc_system_description_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -100,11 +100,11 @@ class FRBCSystemDescriptionTest(TestCase):
         #  assign values during init. See: https://github.com/flexiblepower/s2-ws-json-python/issues/10
         transition = Transition(
             **{
-                "id": uuid.UUID("c32cc1d3-4722-41e3-a8de-55307c723611"),
-                "from": uuid.UUID("2795136c-eb30-4f8a-bdaa-61feba1e71b6"),
-                "to": uuid.UUID("2795136c-eb30-4f8a-bdaa-61feba1e71b6"),
-                "start_timers": [uuid.UUID("e1ff9e58-935b-4765-92e3-5e7679f73eb6")],
-                "blocking_timers": [uuid.UUID("e1ff9e58-935b-4765-92e3-5e7679f73eb6")],
+                "id": "c32cc1d3-4722-41e3-a8de-55307c723611",
+                "from": "2795136c-eb30-4f8a-bdaa-61feba1e71b6",
+                "to": "2795136c-eb30-4f8a-bdaa-61feba1e71b6",
+                "start_timers": ["e1ff9e58-935b-4765-92e3-5e7679f73eb6"],
+                "blocking_timers": ["e1ff9e58-935b-4765-92e3-5e7679f73eb6"],
                 "transition_costs": 1018.4228054114793,
                 "transition_duration": Duration.from_milliseconds(11988),
                 "abnormal_condition_only": True,
@@ -116,7 +116,7 @@ class FRBCSystemDescriptionTest(TestCase):
             [
                 FRBCActuatorDescription(
                     diagnostic_label="some-test-string2728",
-                    id=uuid.UUID("a1061148-f19e-4b1b-8fe3-b506583ce61e"),
+                    id="a1061148-f19e-4b1b-8fe3-b506583ce61e",
                     operation_modes=[
                         FRBCOperationMode(
                             abnormal_condition_only=False,
@@ -144,7 +144,7 @@ class FRBCSystemDescriptionTest(TestCase):
                                     ),
                                 )
                             ],
-                            id=uuid.UUID("2795136c-eb30-4f8a-bdaa-61feba1e71b6"),
+                            id="2795136c-eb30-4f8a-bdaa-61feba1e71b6",
                         )
                     ],
                     supported_commodities=[Commodity.ELECTRICITY],
@@ -154,7 +154,7 @@ class FRBCSystemDescriptionTest(TestCase):
                             duration=Duration.from_timedelta(
                                 timedelta(milliseconds=14099)
                             ),
-                            id=uuid.UUID("e1ff9e58-935b-4765-92e3-5e7679f73eb6"),
+                            id="e1ff9e58-935b-4765-92e3-5e7679f73eb6",
                         )
                     ],
                     transitions=[transition],
@@ -163,7 +163,7 @@ class FRBCSystemDescriptionTest(TestCase):
         )
         self.assertEqual(
             frbc_system_description.message_id,
-            uuid.UUID("97256813-de70-4640-a992-9ae0b2d8e4d1"),
+            "97256813-de70-4640-a992-9ae0b2d8e4d1",
         )
         self.assertEqual(frbc_system_description.message_type, "FRBC.SystemDescription")
         self.assertEqual(
@@ -199,11 +199,11 @@ class FRBCSystemDescriptionTest(TestCase):
         #  assign values during init. See: https://github.com/flexiblepower/s2-ws-json-python/issues/10
         transition = Transition(
             **{
-                "id": uuid.UUID("c32cc1d3-4722-41e3-a8de-55307c723611"),
-                "from": uuid.UUID("2795136c-eb30-4f8a-bdaa-61feba1e71b6"),
-                "to": uuid.UUID("2795136c-eb30-4f8a-bdaa-61feba1e71b6"),
-                "start_timers": [uuid.UUID("e1ff9e58-935b-4765-92e3-5e7679f73eb6")],
-                "blocking_timers": [uuid.UUID("e1ff9e58-935b-4765-92e3-5e7679f73eb6")],
+                "id": "c32cc1d3-4722-41e3-a8de-55307c723611",
+                "from": "2795136c-eb30-4f8a-bdaa-61feba1e71b6",
+                "to": "2795136c-eb30-4f8a-bdaa-61feba1e71b6",
+                "start_timers": ["e1ff9e58-935b-4765-92e3-5e7679f73eb6"],
+                "blocking_timers": ["e1ff9e58-935b-4765-92e3-5e7679f73eb6"],
                 "transition_costs": 1018.4228054114793,
                 "transition_duration": Duration.from_milliseconds(11988),
                 "abnormal_condition_only": True,
@@ -213,7 +213,7 @@ class FRBCSystemDescriptionTest(TestCase):
             actuators=[
                 FRBCActuatorDescription(
                     diagnostic_label="some-test-string2728",
-                    id=uuid.UUID("a1061148-f19e-4b1b-8fe3-b506583ce61e"),
+                    id="a1061148-f19e-4b1b-8fe3-b506583ce61e",
                     operation_modes=[
                         FRBCOperationMode(
                             abnormal_condition_only=False,
@@ -241,7 +241,7 @@ class FRBCSystemDescriptionTest(TestCase):
                                     ),
                                 )
                             ],
-                            id=uuid.UUID("2795136c-eb30-4f8a-bdaa-61feba1e71b6"),
+                            id="2795136c-eb30-4f8a-bdaa-61feba1e71b6",
                         )
                     ],
                     supported_commodities=[Commodity.ELECTRICITY],
@@ -251,13 +251,13 @@ class FRBCSystemDescriptionTest(TestCase):
                             duration=Duration.from_timedelta(
                                 timedelta(milliseconds=14099)
                             ),
-                            id=uuid.UUID("e1ff9e58-935b-4765-92e3-5e7679f73eb6"),
+                            id="e1ff9e58-935b-4765-92e3-5e7679f73eb6",
                         )
                     ],
                     transitions=[transition],
                 )
             ],
-            message_id=uuid.UUID("97256813-de70-4640-a992-9ae0b2d8e4d1"),
+            message_id="97256813-de70-4640-a992-9ae0b2d8e4d1",
             message_type="FRBC.SystemDescription",
             storage=FRBCStorageDescription(
                 diagnostic_label="some-test-string8418",

--- a/tests/unit/frbc/frbc_timer_status_test.py
+++ b/tests/unit/frbc/frbc_timer_status_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -26,7 +26,7 @@ class FRBCTimerStatusTest(TestCase):
         # Assert
         self.assertEqual(
             frbc_timer_status.actuator_id,
-            uuid.UUID("f2e1f540-0235-429f-a45c-4d5cbe65d33f"),
+            "f2e1f540-0235-429f-a45c-4d5cbe65d33f",
         )
         self.assertEqual(
             frbc_timer_status.finished_at,
@@ -42,18 +42,18 @@ class FRBCTimerStatusTest(TestCase):
         )
         self.assertEqual(
             frbc_timer_status.message_id,
-            uuid.UUID("57240f00-0b91-49bb-a4b0-2107d062faec"),
+            "57240f00-0b91-49bb-a4b0-2107d062faec",
         )
         self.assertEqual(frbc_timer_status.message_type, "FRBC.TimerStatus")
         self.assertEqual(
             frbc_timer_status.timer_id,
-            uuid.UUID("bcb8e64f-ea4c-4b92-b4cb-20026a13d663"),
+            "bcb8e64f-ea4c-4b92-b4cb-20026a13d663",
         )
 
     def test__to_json__happy_path_full(self):
         # Arrange
         frbc_timer_status = FRBCTimerStatus(
-            actuator_id=uuid.UUID("f2e1f540-0235-429f-a45c-4d5cbe65d33f"),
+            actuator_id="f2e1f540-0235-429f-a45c-4d5cbe65d33f",
             finished_at=datetime(
                 year=2020,
                 month=11,
@@ -63,9 +63,9 @@ class FRBCTimerStatusTest(TestCase):
                 second=27,
                 tzinfo=offset(offset=timedelta(seconds=7200.0)),
             ),
-            message_id=uuid.UUID("57240f00-0b91-49bb-a4b0-2107d062faec"),
+            message_id="57240f00-0b91-49bb-a4b0-2107d062faec",
             message_type="FRBC.TimerStatus",
-            timer_id=uuid.UUID("bcb8e64f-ea4c-4b92-b4cb-20026a13d663"),
+            timer_id="bcb8e64f-ea4c-4b92-b4cb-20026a13d663",
         )
 
         # Act

--- a/tests/unit/frbc/frbc_usage_forecast_element_test.py
+++ b/tests/unit/frbc/frbc_usage_forecast_element_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *

--- a/tests/unit/frbc/frbc_usage_forecast_test.py
+++ b/tests/unit/frbc/frbc_usage_forecast_test.py
@@ -1,7 +1,7 @@
 from datetime import timedelta, datetime, timezone as offset
 import json
 from unittest import TestCase
-import uuid
+
 
 from s2python.common import *
 from s2python.frbc import *
@@ -51,7 +51,7 @@ class FRBCUsageForecastTest(TestCase):
         )
         self.assertEqual(
             frbc_usage_forecast.message_id,
-            uuid.UUID("4a91b4ab-21fb-42ae-b97d-6170f8b922cc"),
+            "4a91b4ab-21fb-42ae-b97d-6170f8b922cc",
         )
         self.assertEqual(frbc_usage_forecast.message_type, "FRBC.UsageForecast")
         self.assertEqual(
@@ -82,7 +82,7 @@ class FRBCUsageForecastTest(TestCase):
                     usage_rate_upper_limit=8477.800850190179,
                 )
             ],
-            message_id=uuid.UUID("4a91b4ab-21fb-42ae-b97d-6170f8b922cc"),
+            message_id="4a91b4ab-21fb-42ae-b97d-6170f8b922cc",
             message_type="FRBC.UsageForecast",
             start_time=datetime(
                 year=2023,

--- a/tests/unit/s2_parser_test.py
+++ b/tests/unit/s2_parser_test.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from uuid import UUID
 
 from s2python.common import HandshakeResponse
 from s2python.generated.gen_s2 import EnergyManagementRole
@@ -23,7 +22,7 @@ class S2ParserTest(TestCase):
         self.assertEqual(
             parsed_message,
             Handshake(
-                message_id=UUID("ca093515-0bb3-4709-bd56-092c1808b791"),
+                message_id="ca093515-0bb3-4709-bd56-092c1808b791",
                 role=EnergyManagementRole.CEM,
                 supported_protocol_versions=["3.0alpha"],
             ),
@@ -45,7 +44,7 @@ class S2ParserTest(TestCase):
         self.assertEqual(
             parsed_message,
             Handshake(
-                message_id=UUID("ca093515-0bb3-4709-bd56-092c1808b791"),
+                message_id="ca093515-0bb3-4709-bd56-092c1808b791",
                 role=EnergyManagementRole.CEM,
                 supported_protocol_versions=["3.0alpha"],
             ),
@@ -78,7 +77,7 @@ class S2ParserTest(TestCase):
         self.assertEqual(
             parsed_message,
             Handshake(
-                message_id=UUID("ca093515-0bb3-4709-bd56-092c1808b791"),
+                message_id="ca093515-0bb3-4709-bd56-092c1808b791",
                 role=EnergyManagementRole.CEM,
                 supported_protocol_versions=["3.0alpha"],
             ),
@@ -100,7 +99,7 @@ class S2ParserTest(TestCase):
         self.assertEqual(
             parsed_message,
             Handshake(
-                message_id=UUID("ca093515-0bb3-4709-bd56-092c1808b791"),
+                message_id="ca093515-0bb3-4709-bd56-092c1808b791",
                 role=EnergyManagementRole.CEM,
                 supported_protocol_versions=["3.0alpha"],
             ),


### PR DESCRIPTION
Before, the ID was restricted to follow a UUID format while the S2 spec is less restrictive (strings composed by alphanumeric, dashes, underscores and semicolons with a range between 2 and 64).