### PR TITLE
fix: update pydantic requirement to allow higher versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ python_requires >= 3.8, <= 3.12
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
-    pydantic~=2.8.2
+    pydantic>=2.8.2
     pytz
     click
     websockets~=13.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ license_files = LICENSE.txt
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8
 url = https://github.com/flexiblepower/s2-ws-json-python
-version = 0.4.0
+version = 0.4.1
 
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = Linux


### PR DESCRIPTION
This PR removes the pin on pydantic 2.8[^1].

The `pydantic~=2.8.2` requirement from #40 is not compatible with Home Assistant `2025.1`, which runs on `pydantic==2.10`. Generally, libraries should try to set only minimum requirements, unless an actual issue with a higher dependency has been identified.

Inline, next to any dependency constraint, we should try to state the reason for the constraint or even better, cross-reference a GH Issue, so it has a chance of getting resolved later.

[^1]: [Test ran with 2.10.6](https://github.com/flexiblepower/s2-python/actions/runs/12947217156/job/36113329913?pr=76):
     ```
     default: freeze> python -m pip freeze --all
     default: annotated-types==0.7.0,astroid==3.3.8,click==8.1.8,coverage==7.6.10,dill==0.3.9,iniconfig==2.0.0,isort==5.13.2,mccabe==0.7.0,mypy==1.14.1,mypy-extensions==1.0.0,packaging==24.2,pip==24.3.1,platformdirs==4.3.6,pluggy==1.5.0,pydantic==2.10.6,pydantic_core==2.27.2,pylint==3.3.3,pytest==8.3.4,pytest-cov==6.0.0,pytest-cover==3.0.0,pytest-coverage==0.0,pytest-timer==1.0.0,pytz==2024.2,s2-python @ file:///home/runner/work/s2-python/s2-python/dist/s2_python-0.4.0-py3-none-any.whl#sha256=8a6297cf4506dea70740db54e8f49d1ed806dbec08cc4fe743ba5e89b32b549d,tomlkit==0.13.2,types-pytz==2024.2.0.20241221,typing_extensions==4.12.2,websockets==13.1
     ```