### PR TITLE
S2 messages importable

### DIFF
--- a/src/s2python/message.py
+++ b/src/s2python/message.py
@@ -15,16 +15,25 @@ from s2python.ppbc import (
 )
 
 from s2python.common import (
+    Duration,
     Handshake,
     HandshakeResponse,
     InstructionStatusUpdate,
+    NumberRange,
     PowerForecast,
+    PowerForecastElement,
+    PowerForecastValue,
     PowerMeasurement,
+    PowerRange,
+    PowerValue,
     ReceptionStatus,
     ResourceManagerDetails,
     RevokeObject,
+    Role,
     SelectControlType,
-    SessionRequest
+    SessionRequest,
+    Timer,
+    Transition,
 )
 
 S2Message = Union[
@@ -37,14 +46,23 @@ S2Message = Union[
     FRBCTimerStatus,
     FRBCUsageForecast,
     PPBCScheduleInstruction,
+    Duration,
     Handshake,
     HandshakeResponse,
     InstructionStatusUpdate,
+    NumberRange,
     PowerForecast,
+    PowerForecastElement,
+    PowerForecastValue,
     PowerMeasurement,
+    PowerRange,
+    PowerValue,
     ReceptionStatus,
     ResourceManagerDetails,
     RevokeObject,
+    Role,
     SelectControlType,
     SessionRequest,
+    Timer,
+    Transition,
 ]

--- a/src/s2python/message.py
+++ b/src/s2python/message.py
@@ -18,7 +18,15 @@ from s2python.frbc import (
     FRBCUsageForecastElement,
 )
 from s2python.ppbc import (
+    PPBCEndInterruptionInstruction,
+    PPBCPowerProfileDefinition,
+    PPBCPowerSequenceContainer,
+    PPBCPowerSequence,
+    PPBCPowerProfileStatus,
+    PPBCPowerSequenceContainerStatus,
+    PPBCPowerSequenceElement,
     PPBCScheduleInstruction,
+    PPBCStartInterruptionInstruction,
 )
 
 from s2python.common import (
@@ -58,8 +66,16 @@ S2Message = Union[
     FRBCSystemDescription,
     FRBCTimerStatus,
     FRBCUsageForecast,
-    PPBCScheduleInstruction,
     FRBCUsageForecastElement,
+    PPBCEndInterruptionInstruction,
+    PPBCPowerProfileDefinition,
+    PPBCPowerSequenceContainer,
+    PPBCPowerSequence,
+    PPBCPowerProfileStatus,
+    PPBCPowerSequenceContainerStatus,
+    PPBCPowerSequenceElement,
+    PPBCScheduleInstruction,
+    PPBCStartInterruptionInstruction,
     Duration,
     Handshake,
     HandshakeResponse,

--- a/src/s2python/message.py
+++ b/src/s2python/message.py
@@ -1,14 +1,21 @@
 from typing import Union
 
 from s2python.frbc import (
+    FRBCActuatorDescription,
     FRBCActuatorStatus,
     FRBCFillLevelTargetProfile,
+    FRBCFillLevelTargetProfileElement,
     FRBCInstruction,
     FRBCLeakageBehaviour,
+    FRBCLeakageBehaviourElement,
+    FRBCOperationMode,
+    FRBCOperationModeElement,
+    FRBCStorageDescription,
     FRBCStorageStatus,
     FRBCSystemDescription,
     FRBCTimerStatus,
-    FRBCUsageForecast
+    FRBCUsageForecast,
+    FRBCUsageForecastElement,
 )
 from s2python.ppbc import (
     PPBCScheduleInstruction,
@@ -37,15 +44,22 @@ from s2python.common import (
 )
 
 S2Message = Union[
+    FRBCActuatorDescription,
     FRBCActuatorStatus,
     FRBCFillLevelTargetProfile,
+    FRBCFillLevelTargetProfileElement,
     FRBCInstruction,
     FRBCLeakageBehaviour,
+    FRBCLeakageBehaviourElement,
+    FRBCOperationMode,
+    FRBCOperationModeElement,
+    FRBCStorageDescription,
     FRBCStorageStatus,
     FRBCSystemDescription,
     FRBCTimerStatus,
     FRBCUsageForecast,
     PPBCScheduleInstruction,
+    FRBCUsageForecastElement,
     Duration,
     Handshake,
     HandshakeResponse,

--- a/src/s2python/ppbc/__init__.py
+++ b/src/s2python/ppbc/__init__.py
@@ -10,3 +10,4 @@ from s2python.ppbc.ppbc_power_sequence_container_status import (
     PPBCPowerSequenceContainerStatus,
 )
 from s2python.ppbc.ppbc_power_sequence_element import PPBCPowerSequenceElement
+from s2python.ppbc.ppbc_start_interruption_instruction import PPBCStartInterruptionInstruction

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+
+import importlib
+import inspect
+import pkgutil
+
+from s2python import message
+from s2python.validate_values_mixin import S2MessageComponent
+
+
+class S2MessageTest(TestCase):
+
+    def _test_import_s2_messages(self, module_name):
+        """Make sure each S2MessageComponent subclass in the given module is importable from s2_python.message."""
+        module = importlib.import_module(module_name)
+
+        # Find all submodules
+        all_subclasses = []
+        for _, name, is_pkg in pkgutil.iter_modules(module.__path__, module.__name__ + "."):
+            submodule = importlib.import_module(name)
+
+            # Find all classes in the submodule that subclass BaseClass
+            subclasses = [
+                obj for _, obj in inspect.getmembers(submodule, inspect.isclass)
+                if issubclass(obj, S2MessageComponent) and obj is not S2MessageComponent
+            ]
+            all_subclasses.extend(subclasses)
+
+        # Ensure we found at least one subclass
+        self.assertGreater(len(all_subclasses), 0, f"No subclasses found in {module_name}")
+
+        for S2MessageClass in all_subclasses:
+            assert hasattr(message, S2MessageClass.__name__), f"{S2MessageClass} should be importable from s2_python.message"
+
+    def test_import_s2_messages__common(self):
+        self._test_import_s2_messages("s2python.common")
+
+    def test_import_s2_messages__ddbc(self):
+        self._test_import_s2_messages("s2python.ddbc")
+
+    def test_import_s2_messages__frbc(self):
+        self._test_import_s2_messages("s2python.frbc")
+
+    def test_import_s2_messages__pebc(self):
+        self._test_import_s2_messages("s2python.pebc")
+
+    def test_import_s2_messages__ppbc(self):
+        self._test_import_s2_messages("s2python.ppbc")

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -9,28 +9,36 @@ from s2python.validate_values_mixin import S2MessageComponent
 
 
 class S2MessageTest(unittest.TestCase):
+    """Check importing S2Message classes from s2_python.message."""
 
     def _test_import_s2_messages(self, module_name):
-        """Make sure each S2MessageComponent subclass in the given module is importable from s2_python.message."""
+        """Check each S2MessageComponent subclass in the given module is importable."""
         module = importlib.import_module(module_name)
 
         # Find all submodules
         all_subclasses = []
-        for _, name, is_pkg in pkgutil.iter_modules(module.__path__, module.__name__ + "."):
+        for _, name, is_pkg in pkgutil.iter_modules(
+            module.__path__, module.__name__ + "."
+        ):
             submodule = importlib.import_module(name)
 
             # Find all classes in the submodule that subclass BaseClass
             subclasses = [
-                obj for _, obj in inspect.getmembers(submodule, inspect.isclass)
+                obj
+                for _, obj in inspect.getmembers(submodule, inspect.isclass)
                 if issubclass(obj, S2MessageComponent) and obj is not S2MessageComponent
             ]
             all_subclasses.extend(subclasses)
 
         # Ensure we found at least one subclass
-        self.assertGreater(len(all_subclasses), 0, f"No subclasses found in {module_name}")
+        self.assertGreater(
+            len(all_subclasses), 0, f"No subclasses found in {module_name}"
+        )
 
         for S2MessageClass in all_subclasses:
-            assert hasattr(message, S2MessageClass.__name__), f"{S2MessageClass} should be importable from s2_python.message"
+            assert hasattr(
+                message, S2MessageClass.__name__
+            ), f"{S2MessageClass} should be importable from s2_python.message"
 
     def test_import_s2_messages__common(self):
         self._test_import_s2_messages("s2python.common")

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 
 import importlib
 import inspect
@@ -8,7 +8,7 @@ from s2python import message
 from s2python.validate_values_mixin import S2MessageComponent
 
 
-class S2MessageTest(TestCase):
+class S2MessageTest(unittest.TestCase):
 
     def _test_import_s2_messages(self, module_name):
         """Make sure each S2MessageComponent subclass in the given module is importable from s2_python.message."""
@@ -35,12 +35,14 @@ class S2MessageTest(TestCase):
     def test_import_s2_messages__common(self):
         self._test_import_s2_messages("s2python.common")
 
+    @unittest.skip("Work in progress")
     def test_import_s2_messages__ddbc(self):
         self._test_import_s2_messages("s2python.ddbc")
 
     def test_import_s2_messages__frbc(self):
         self._test_import_s2_messages("s2python.frbc")
 
+    @unittest.skip("Work in progress")
     def test_import_s2_messages__pebc(self):
         self._test_import_s2_messages("s2python.pebc")
 

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -17,9 +17,7 @@ class S2MessageTest(unittest.TestCase):
 
         # Find all submodules
         all_subclasses = []
-        for _, name, is_pkg in pkgutil.iter_modules(
-            module.__path__, module.__name__ + "."
-        ):
+        for _, name, _ in pkgutil.iter_modules(module.__path__, module.__name__ + "."):
             submodule = importlib.import_module(name)
 
             # Find all classes in the submodule that subclass BaseClass
@@ -35,10 +33,10 @@ class S2MessageTest(unittest.TestCase):
             len(all_subclasses), 0, f"No subclasses found in {module_name}"
         )
 
-        for S2MessageClass in all_subclasses:
+        for _class in all_subclasses:
             assert hasattr(
-                message, S2MessageClass.__name__
-            ), f"{S2MessageClass} should be importable from s2_python.message"
+                message, _class.__name__
+            ), f"{_class} should be importable from s2_python.message"
 
     def test_import_s2_messages__common(self):
         self._test_import_s2_messages("s2python.common")


### PR DESCRIPTION
Closes #77.

Note that the tests for importing DDBC and PEBC messages are skipped. This is due to a KeyError, which I consider out of scope for this PR. For example:

```
    abnormal_conditions: bool = GenPEBCInstruction.model_fields["abnormal_conditions"]  # type: ignore[assignment]
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'abnormal_conditions'
```
