### PR TITLE
dropping python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"  # newest Python that is stable
+          - "3.12"
+          - "3.13"  # newest Python that is stable          
         platform:
         - ubuntu-latest
         # - macos-latest
@@ -97,7 +98,8 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"  # newest Python that is stable
+          - "3.12"
+          - "3.13"  # newest Python that is stable
         platform:
         - ubuntu-latest
         # - macos-latest
@@ -125,7 +127,8 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"  # newest Python that is stable
+          - "3.12"
+          - "3.13"  # newest Python that is stable          
         platform:
         - ubuntu-latest
         # - macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,7 @@ jobs:
       - name: Run tests
         run: >-
           pipx run --python '${{ steps.setup-python.outputs.python-path }}'
-          tox --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
-          -- -rFEx --durations 10 --color yes  # pytest args
+          tox --develop -rFEx --durations 10 --color yes  # pytest args  
       # - name: Generate coverage report
       #   run: pipx run coverage lcov -o coverage.lcov
       # - name: Upload partial coverage report
@@ -116,7 +115,7 @@ jobs:
       - name: Run tests
         run: >-
           pipx run --python '${{ steps.setup-python.outputs.python-path }}'
-          tox -e lint --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
+          tox -e lint --develop
 
   typecheck:
     needs: prepare
@@ -144,7 +143,7 @@ jobs:
       - name: Run tests
         run: >-
           pipx run --python '${{ steps.setup-python.outputs.python-path }}'
-          tox -e typecheck --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
+          tox -e typecheck --develop
 
   finalize:
     needs: [test, lint, typecheck]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -96,7 +95,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -125,7 +123,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run tests
         run: >-
           pipx run --python '${{ steps.setup-python.outputs.python-path }}'
-          tox --develop -rFEx --durations 10 --color yes  # pytest args  
+          tox --develop
       # - name: Generate coverage report
       #   run: pipx run coverage lcov -o coverage.lcov
       # - name: Upload partial coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.5.0"
 readme = "README.rst"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.9, <= 3.13"
+requires-python = ">=3.9, < 3.14"
 dependencies = [
     "pydantic>=2.8.2",
     "pytz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.5.0"
 readme = "README.rst"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-requires-python = ">=3.8, < 3.13"
+requires-python = ">=3.9, <= 3.13"
 dependencies = [
     "pydantic>=2.8.2",
     "pytz",
@@ -20,11 +20,11 @@ dependencies = [
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",    
 ]
 [project.urls]
     "Source code" = "https://github.com/flexiblepower/s2-ws-json-python"


### PR DESCRIPTION
Looks like github actions dropped support fro python 3.8 on ubuntu latest, I suggest dropping 3.8 and adding 3.13