### PR TITLE
Added PEBC message types to the S2 Parser TYPE_TO_MESSAGE_CLASS dictionary

### DIFF
--- a/src/s2python/s2_parser.py
+++ b/src/s2python/s2_parser.py
@@ -24,9 +24,7 @@ from s2python.frbc import (
     FRBCTimerStatus,
     FRBCUsageForecast,
 )
-from s2python.pebc import (
-    PEBCPowerConstraints,
-)
+from s2python.pebc import PEBCPowerConstraints, PEBCEnergyConstraint, PEBCInstruction
 from s2python.ppbc import PPBCScheduleInstruction
 
 from s2python.message import S2Message
@@ -52,6 +50,8 @@ TYPE_TO_MESSAGE_CLASS: Dict[str, Type[S2Message]] = {
     "FRBC.UsageForecast": FRBCUsageForecast,
     "PPBC.ScheduleInstruction": PPBCScheduleInstruction,
     "PEBC.PowerConstraints": PEBCPowerConstraints,
+    "PEBC.Instruction": PEBCInstruction,
+    "PEBC.EnergyConstraint": PEBCEnergyConstraint,
     "Handshake": Handshake,
     "HandshakeResponse": HandshakeResponse,
     "InstructionStatusUpdate": InstructionStatusUpdate,

--- a/src/s2python/s2_parser.py
+++ b/src/s2python/s2_parser.py
@@ -24,6 +24,9 @@ from s2python.frbc import (
     FRBCTimerStatus,
     FRBCUsageForecast,
 )
+from s2python.pebc import (
+    PEBCPowerConstraints,
+)
 from s2python.ppbc import PPBCScheduleInstruction
 
 from s2python.message import S2Message
@@ -48,6 +51,7 @@ TYPE_TO_MESSAGE_CLASS: Dict[str, Type[S2Message]] = {
     "FRBC.TimerStatus": FRBCTimerStatus,
     "FRBC.UsageForecast": FRBCUsageForecast,
     "PPBC.ScheduleInstruction": PPBCScheduleInstruction,
+    "PEBC.PowerConstraints": PEBCPowerConstraints,
     "Handshake": Handshake,
     "HandshakeResponse": HandshakeResponse,
     "InstructionStatusUpdate": InstructionStatusUpdate,
@@ -90,7 +94,9 @@ class S2Parser:
         return TYPE_TO_MESSAGE_CLASS[message_type].model_validate(message_json)
 
     @staticmethod
-    def parse_as_message(unparsed_message: Union[dict, str, bytes], as_message: Type[M]) -> M:
+    def parse_as_message(
+        unparsed_message: Union[dict, str, bytes], as_message: Type[M]
+    ) -> M:
         """Parse the message to a specific S2 python message.
 
         :param unparsed_message: The message as a JSON-formatted string or as a JSON-parsed dictionary.


### PR DESCRIPTION
Fixing issue I raised in #109. I added the `PEBCPowerConstraints` message type to the `TYPE_TO_MESSAGE_CLASS ` dictionary to allow this PEBC specific message to be parsed by the S2 Parser. 