### PR TITLE
fix_validator_pebc_allowed_range: start of range should always be low…

### DIFF
--- a/src/s2python/pebc/pebc_allowed_limit_range.py
+++ b/src/s2python/pebc/pebc_allowed_limit_range.py
@@ -29,12 +29,7 @@ class PEBCAllowedLimitRange(GenPEBCAllowedLimitRange, S2MessageComponent):
 
     @model_validator(mode="after")
     def validate_range_boundary(self) -> Self:
-        # According to the specification "There must be at least one PEBC.AllowedLimitRange for the UPPER_LIMIT
-        # and at least one AllowedLimitRange for the LOWER_LIMIT." However for something that produces energy
-        # end_of_range=-2000 and start_of_range=0 is valid. Therefore absolute value used here.
-        if abs(self.range_boundary.start_of_range) > abs(
-            self.range_boundary.end_of_range
-        ):
+        if self.range_boundary.start_of_range > self.range_boundary.end_of_range:
             raise ValueError(
                 self,
                 "The start of the range must be smaller or equal than the end of the range.",

--- a/tests/unit/pebc/pebc_power_constraints_test.py
+++ b/tests/unit/pebc/pebc_power_constraints_test.py
@@ -33,8 +33,8 @@ class PEBCPowerConstraintsTest(TestCase):
             "commodity_quantity": "ELECTRIC.POWER.L1",
             "limit_type": "LOWER_LIMIT",
             "range_boundary": {
-                "start_of_range": 0.0,
-                "end_of_range": -2000.0
+                "start_of_range": -2000.0,
+                "end_of_range": 0.0
             },
             "abnormal_condition_only": false
         }
@@ -43,9 +43,7 @@ class PEBCPowerConstraintsTest(TestCase):
         """
 
         # Act
-        pebc_power_constraints: PEBCPowerConstraints = PEBCPowerConstraints.from_json(
-            json_str
-        )
+        pebc_power_constraints: PEBCPowerConstraints = PEBCPowerConstraints.from_json(json_str)
 
         self.assertEqual(
             pebc_power_constraints.id,
@@ -124,9 +122,7 @@ class PEBCPowerConstraintsTest(TestCase):
                 PEBCAllowedLimitRange(
                     commodity_quantity=CommodityQuantity.ELECTRIC_POWER_L1,
                     limit_type=PEBCPowerEnvelopeLimitType.LOWER_LIMIT,
-                    range_boundary=NumberRange(
-                        start_of_range=0.0, end_of_range=-2000.0
-                    ),
+                    range_boundary=NumberRange(start_of_range=-2000.0, end_of_range=0.0),
                     abnormal_condition_only=False,
                 ),
             ],
@@ -153,7 +149,7 @@ class PEBCPowerConstraintsTest(TestCase):
                 {
                     "commodity_quantity": "ELECTRIC.POWER.L1",
                     "limit_type": "LOWER_LIMIT",
-                    "range_boundary": {"start_of_range": 0.0, "end_of_range": -2000.0},
+                    "range_boundary": {"start_of_range": -2000.0, "end_of_range": 0.0},
                     "abnormal_condition_only": False,
                 },
             ],
@@ -175,8 +171,8 @@ class PEBCPowerConstraintsTest(TestCase):
             "commodity_quantity": "ELECTRIC.POWER.L1",
             "limit_type": "LOWER_LIMIT",
             "range_boundary": {
-                "start_of_range": 0.0,
-                "end_of_range": -2000.0
+                "start_of_range": -2000.0,
+                "end_of_range": 0.0
             },
             "abnormal_condition_only": false
         }
@@ -236,8 +232,8 @@ class PEBCPowerConstraintsTest(TestCase):
             "commodity_quantity": "ELECTRIC.POWER.L1",
             "limit_type": "LOWER_LIMIT",
             "range_boundary": {
-                "start_of_range": 0.0,
-                "end_of_range": -2000.0
+                "start_of_range": -2000.0,
+                "end_of_range": 0.0
             },
             "abnormal_condition_only": false
         }


### PR DESCRIPTION
…er than end of range in PEBC AllowedRanges.